### PR TITLE
Fix duplicate addresses and format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,8 @@ fn run_app<B: Backend>(
                     Command::Listen => {
                         app.listening = !app.listening;
                         if app.listening {
-                            let receiver = net_utils::listener::spawn_listener(&app);
+                            let receiver =
+                                net_utils::listener::spawn_listener(&app);
                             app.listen_thread_rx = Some(receiver);
                         } else {
                             net_utils::listener::kill_listener(&app);

--- a/src/term_utils/ui/banner.rs
+++ b/src/term_utils/ui/banner.rs
@@ -25,7 +25,7 @@ pub(crate) fn banner_element(app: &App) -> Paragraph<'_> {
                 Style::default().add_modifier(Modifier::BOLD),
             ),
         ],
-        Style::default()
+        Style::default(),
     );
     let mut text = Text::from(Line::from(banner_text));
     text.patch_style(banner_style);


### PR DESCRIPTION
SiliconSelf found the fix for the duplicate addresses -- changing `Vec<Host>` to `HashSet<Host>` -- and I bumped up the efficiency of the listener thread by replacing its internal `Vec<MacAddr>` with a `HashSet<MacAddr>`. If I knew how to do that git thing where a single commit has multiple authors, I would do that in the interest of proper credit.

The thread was already checking for duplicates long before I touched it, so how duplicates ended up in the `hosts` vector is lost on both of us. Regardless, switching from a list to a set makes the duplicates impossible.

After I finished making changes, I made sure nightly clippy with lints didn't generate any ~~new~~ warnings and then ran rustfmt on the whole project.